### PR TITLE
refactor: remove 'isA ValueFailure' test in test_failure helper

### DIFF
--- a/lib/src/helpers/test_failure.dart
+++ b/lib/src/helpers/test_failure.dart
@@ -7,10 +7,6 @@ void testValueFailure<T extends Object>({
   required T invalidValue,
   required ValueFailure<T> failure,
 }) {
-  test("should be a ValueFailure", () {
-    expect(failure, isA<ValueFailure>());
-  });
-
   test("should contain the invalid value", () {
     expect(failure.invalidValue, invalidValue);
   });


### PR DESCRIPTION
The `failure` parameter will always be a `ValueFailure` since it's enforced by the parameter type.