### PR TITLE
feat: add helper functions to test validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Add helper functions to test validators: `testValidatorOnValidValue`, `testValidatorOnValidValues`,
+  `testValidatorOnInvalidValue`, `testValidatorOnInvalidValues`
+
 ## 1.4.1
 
 - Fix an issue causing the failure of `pub get` for packages

--- a/README.md
+++ b/README.md
@@ -1,3 +1,80 @@
 # flutter_clean_domain_test
 
 A package that provides a testing framework for packages that depends on flutter_clean_domain
+
+## Usage
+### Test a validator
+A validator is a function used by a `ValueObject` to make sure that the value it stores is valid.
+In case the value is valid it returns a `Right` containing it; otherwise it returns a `Left`
+containing a `ValueFailure` which in turn contains the invalid value.
+
+The package provides helper functions for testing both the case of valid and invalid values.
+
+#### Test the case of a valid value
+Use the `testValidatorOnValidValue` helper function. 
+
+Pass your validator function as argument and provide the valid value you want to test
+your validator to.
+
+```dart
+  testValidatorOnValidValue<ValueType>(
+    "a message that describe the test",
+    validator: myValidator,
+    validValue: aValidValue,
+);
+```
+
+#### Test multiple valid values at once
+Use the `testValidatorOnValidValues` helper function.
+
+Pass your validator function as argument and provide the valid values you want to test
+your validator to. The function accepts any `Iterable` on the `validValues` argument, but you 
+should prefer to pass a `List`.
+
+```dart
+    
+testValidatorOnValidValues<ValueType>(
+    "a message that describe the test group",
+    validator: myValidator,
+    validValues: [validValue1, validValue2, validValue3],
+ );
+```
+
+#### Test the case of an invalid value
+Use the `testValidatorOnInvalidValue` helper function.
+
+Pass your validator function as argument and provide the invalid value you want to test
+your validator to. 
+You also have to pass a factory function that builds the `ValueFailure` that
+you expect the validator should return when called with that specific invalid value.
+
+```dart
+  testValidatorOnInvalidValue<ValueType>(
+    "a message that describe the test",
+    validator: myValidator,
+    invalidValue: anInvalidValue,
+    valueFailureFactory: (invalidValue) =>
+        AValueFailure(invalidValue: invalidValue),
+  );
+```
+
+#### Test multiple invalid values at once
+
+Use the `testValidatorOnInvalidValues` helper function.
+
+Pass your validator function as argument and provide the invalid values you want to test
+your validator to. The function accepts any `Iterable` on the `invalidValues` argument, but you
+should prefer to pass a `List`.
+
+You also have to pass a factory function that builds the `ValueFailure` that
+you expect the validator should return when called with that specific invalid value.
+
+```dart
+  testValidatorOnInvalidValues<int>(
+    "a message that describe the test group",
+    validator: myValidator,
+    invalidValues: [invalidValue1, invalidValue2, invalidValue3],
+    valueFailureFactory: (invalidValue) =>
+      AValueFailure(invalidValue: invalidValue),
+  );
+```

--- a/lib/src/helpers/test_validator.dart
+++ b/lib/src/helpers/test_validator.dart
@@ -1,0 +1,104 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_clean_domain/flutter_clean_domain.dart';
+import 'package:test/test.dart';
+
+/// Tests the given [validator] in the case of a valid value.
+/// Checks that it properly returns a [Right] containing the given [validValue].
+///
+/// It is possible to specify a [message], which will be used as test description.
+/// If [message] is not passed a default description is used.
+void testValidatorOnValidValue<T extends Object>(
+  String? message, {
+  required final Either<ValueFailure<T>, T> Function(T) validator,
+  required final T validValue,
+}) {
+  if (message == null || message.isEmpty) {
+    message = "should return a Right when a valid value is passed";
+  }
+
+  test(message, () {
+    final validationResult = validator(validValue);
+
+    expect(validationResult, Right<ValueFailure<T>, T>(validValue));
+  });
+}
+
+/// Test the given [validator] over multiple valid values.
+///
+/// It is possible to specify a [message], which will be used as description
+/// of the test group. If [message] is not passed a default description is used.
+void testValidatorOnValidValues<T extends Object>(
+  String? message, {
+  required final Either<ValueFailure<T>, T> Function(T) validator,
+  required final Iterable<T> validValues,
+}) {
+  if (message == null || message.isEmpty) {
+    message = "test validator on valid values";
+  }
+  group(message, () {
+    for (final validValue in validValues) {
+      testValidatorOnValidValue(
+        "should return a Right when $validValue is passed",
+        validator: validator,
+        validValue: validValue,
+      );
+    }
+  });
+}
+
+/// Tests the given [validator] on the case of an invalid value.
+/// Checks that the return is a [Left] containing a specific [valueFailure]
+/// which in turn contains the [invalidValue].
+///
+/// [valueFailureFactory] should create the [ValueFailure] containing the
+/// invalid value being tested.
+///
+/// It is possible to specify a [message], which will be used as test description.
+/// If [message] is not passed a default description is used.
+void testValidatorOnInvalidValue<T extends Object>(
+  String? message, {
+  required final Either<ValueFailure<T>, T> Function(T) validator,
+  required final T invalidValue,
+  required final ValueFailure<T> Function(T invalidValue) valueFailureFactory,
+}) {
+  if (message == null || message.isEmpty) {
+    message = "should return a Left containing a value failure when an invalid "
+        "value is passed";
+  }
+
+  test(message, () {
+    final validationResult = validator(invalidValue);
+
+    expect(validationResult,
+        Left<ValueFailure<T>, T>(valueFailureFactory(invalidValue)));
+  });
+}
+
+/// Test the given [validator] over multiple invalid values.
+///
+/// [valueFailureFactory] should create the [ValueFailure] containing the
+/// invalid value being tested.
+///
+/// It is possible to specify a [message], which will be used as description
+/// of the test group. If [message] is not passed a default description is used.
+void testValidatorOnInvalidValues<T extends Object>(
+  String? message, {
+  required final Either<ValueFailure<T>, T> Function(T) validator,
+  required final Iterable<T> invalidValues,
+  required final ValueFailure<T> Function(T invalidValue) valueFailureFactory,
+}) {
+  if (message == null || message.isEmpty) {
+    message = "test validator on invalid values";
+  }
+
+  group(message, () {
+    for (final invalidValue in invalidValues) {
+      testValidatorOnInvalidValue(
+        "should return a Left when $invalidValue is passed",
+        validator: validator,
+        invalidValue: invalidValue,
+        valueFailureFactory: valueFailureFactory,
+      );
+    }
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   mocktail: ^0.3.0
+  dartz: ^0.10.1
 
   flutter_clean_domain:
     git:

--- a/test/helpers/test_validator_test.dart
+++ b/test/helpers/test_validator_test.dart
@@ -1,0 +1,60 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_clean_domain/flutter_clean_domain.dart';
+import 'package:flutter_clean_domain_test/src/helpers/test_validator.dart';
+
+class IntValueObject extends ValueObject<int> {
+  final Either<ValueFailure<int>, int> _value;
+
+  IntValueObject(Either<ValueFailure<int>, int> value) : _value = value;
+  @override
+  Either<ValueFailure<int>, int> get value => _value;
+}
+
+class IntValueFailure extends ValueFailure<int> {
+  IntValueFailure({required int invalidValue})
+      : super(invalidValue: invalidValue);
+}
+
+Either<ValueFailure<int>, int> intValidator(final int value) {
+  return value >= 10
+      ? Right(value)
+      : Left(IntValueFailure(invalidValue: value));
+}
+
+void main() {
+  final int validIntValue = 10;
+  final validIntValues = <int>[12, 13, 14, 15];
+  final int invalidIntValue = 5;
+  final invalidIntValues = <int>[0, 1, 2, 3];
+
+  final IntValueFailure valueFailure =
+      IntValueFailure(invalidValue: invalidIntValue);
+
+  testValidatorOnValidValue<int>(
+    "should return a Right when 10 is passed",
+    validator: intValidator,
+    validValue: validIntValue,
+  );
+
+  testValidatorOnInvalidValue<int>(
+    "should return a Left when 5 is passed",
+    validator: intValidator,
+    invalidValue: invalidIntValue,
+    valueFailureFactory: (invalidValue) =>
+        IntValueFailure(invalidValue: invalidValue),
+  );
+
+  testValidatorOnValidValues<int>(
+    "test intValidator on valid values",
+    validator: intValidator,
+    validValues: validIntValues,
+  );
+
+  testValidatorOnInvalidValues<int>(
+    "test intValidator on invalid values",
+    validator: intValidator,
+    invalidValues: invalidIntValues,
+    valueFailureFactory: (invalidValue) =>
+        IntValueFailure(invalidValue: invalidValue),
+  );
+}


### PR DESCRIPTION
With this PR 4 helper functions are added to test validators:
- `testValidatorOnValidValue`
- `testValidatorOnValidValues`
- `testValidatorOnInvalidValue`
- `testValidatorOnInvalidValues`

Both implementation and test are added, as well as the README is updated with documentation on how to use them.